### PR TITLE
Add Go voice microservice with Deepgram STT, ElevenLabs TTS, and OpenAI-powered dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ logs/
 
 # temp files
 temp/
+
+# Go voice service binaries
+voice-service/voice-service
+voice-service/*.exe

--- a/VOICE_MIGRATION_GUIDE.md
+++ b/VOICE_MIGRATION_GUIDE.md
@@ -1,0 +1,256 @@
+# Voice Service Migration Guide
+
+## What Changed
+
+You've successfully migrated from Vapi to a custom Go microservice for voice handling. Here's what's new:
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Browser (components/Agent.tsx)                             │
+│  - Captures mic audio via getUserMedia                      │
+│  - WebSocket connection to voice service                    │
+│  - Displays transcripts and plays TTS audio                 │
+└─────────────────────────────────────────────────────────────┘
+                          │
+                          │ WebSocket (audio + control)
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Voice Service (Go) - voice-service/                        │
+│  - WebSocket server (port 8080)                             │
+│  - AssemblyAI streaming STT                                 │
+│  - ElevenLabs TTS                                           │
+│  - Dialog FSM for collecting interview parameters           │
+│  - POST to main app when complete                           │
+└─────────────────────────────────────────────────────────────┘
+                          │
+                          │ HTTP POST
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Main Next.js App (Vercel)                                  │
+│  - POST /api/vapi/generate (unchanged)                      │
+│  - Firestore, Gemini, PDF extraction                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Files Changed
+
+**New Files:**
+- `voice-service/` - Complete Go microservice
+  - `main.go` - WebSocket server
+  - `session.go` - Session management
+  - `dialog.go` - Dialog state machine
+  - `assemblyai.go` - STT client
+  - `elevenlabs.go` - TTS client
+  - `generate.go` - HTTP client for main app
+- `lib/voice-client.ts` - Browser WebSocket client
+
+**Modified Files:**
+- `components/Agent.tsx` - Uses VoiceClient instead of Vapi
+- `env.example` - Added NEXT_PUBLIC_VOICE_SERVICE_URL
+
+**Unchanged:**
+- `app/api/vapi/generate/route.ts` - Still handles interview generation
+- All Firestore/Firebase logic
+- All UI components
+
+## Setup Instructions
+
+### 1. Set Up Voice Service
+
+```bash
+cd voice-service
+
+# Copy environment template
+cp .env.example .env
+
+# Edit .env with your API keys
+# Required:
+# - ASSEMBLYAI_API_KEY (get from https://www.assemblyai.com/)
+# - ELEVENLABS_API_KEY (get from https://elevenlabs.io/)
+# - MAIN_APP_URL (your Next.js app URL)
+```
+
+### 2. Get API Keys
+
+**AssemblyAI:**
+1. Sign up at https://www.assemblyai.com/
+2. Go to Dashboard → API Keys
+3. Copy your API key
+
+**ElevenLabs:**
+1. Sign up at https://elevenlabs.io/
+2. Go to Profile → API Keys
+3. Copy your API key
+4. (Optional) Get a voice ID from Voices page
+
+### 3. Run Voice Service Locally
+
+```bash
+cd voice-service
+
+# Install dependencies
+go mod download
+
+# Run the service
+go run .
+```
+
+Service will start on `http://localhost:8080`
+
+Test health endpoint:
+```bash
+curl http://localhost:8080/health
+```
+
+### 4. Configure Main App
+
+In your main app's `.env.local`:
+
+```bash
+# For local development
+NEXT_PUBLIC_VOICE_SERVICE_URL=ws://localhost:8080/voice
+
+# For production (after deploying voice service)
+# NEXT_PUBLIC_VOICE_SERVICE_URL=wss://your-voice-service.fly.dev/voice
+```
+
+### 5. Run Main App
+
+```bash
+# In the main project directory
+npm run dev
+```
+
+### 6. Test the Integration
+
+1. Navigate to your interview page
+2. Click "Call" button
+3. Allow microphone access
+4. Speak your answers to the prompts
+5. The agent will:
+   - Ask for role, type, level, tech stack, amount
+   - Generate interview via your existing API
+   - Confirm completion
+
+## Deployment
+
+### Deploy Voice Service to Fly.io (Recommended)
+
+```bash
+cd voice-service
+
+# Install flyctl
+brew install flyctl  # or curl -L https://fly.io/install.sh | sh
+
+# Login
+fly auth login
+
+# Launch (creates fly.toml)
+fly launch
+
+# Set secrets
+fly secrets set ASSEMBLYAI_API_KEY=your-key
+fly secrets set ELEVENLABS_API_KEY=your-key
+fly secrets set MAIN_APP_URL=https://evalia-tau.vercel.app
+fly secrets set ALLOWED_ORIGINS=https://evalia-tau.vercel.app
+
+# Deploy
+fly deploy
+```
+
+Your service will be at `wss://your-app-name.fly.dev/voice`
+
+### Deploy Voice Service to Railway
+
+```bash
+cd voice-service
+
+# Install Railway CLI
+npm install -g @railway/cli
+
+# Login
+railway login
+
+# Initialize
+railway init
+
+# Set environment variables in Railway dashboard
+# Then deploy
+railway up
+```
+
+### Update Main App Environment
+
+After deploying voice service, update your main app's environment:
+
+**Vercel:**
+1. Go to your project settings
+2. Environment Variables
+3. Add/update: `NEXT_PUBLIC_VOICE_SERVICE_URL=wss://your-voice-service.fly.dev/voice`
+4. Redeploy
+
+## Troubleshooting
+
+### Voice service won't start
+- Check Go version: `go version` (need 1.21+)
+- Verify .env file exists and has API keys
+- Check port 8080 is not in use: `lsof -i :8080`
+
+### Can't connect from browser
+- Ensure voice service is running
+- Check NEXT_PUBLIC_VOICE_SERVICE_URL is set correctly
+- For local dev, use `ws://` not `wss://`
+- Check browser console for WebSocket errors
+
+### AssemblyAI errors
+- Verify API key is correct
+- Check account has available credits
+- Ensure sample rate is 16000 Hz
+
+### ElevenLabs errors
+- Verify API key is correct
+- Check account has available characters
+- Try default voice ID if custom one fails
+
+### Interview not generating
+- Check voice service logs for POST errors
+- Verify MAIN_APP_URL is correct
+- Ensure /api/vapi/generate endpoint is accessible
+- Check main app logs on Vercel
+
+### Audio quality issues
+- AssemblyAI expects 16kHz mono audio
+- Check microphone permissions in browser
+- Try different browser if issues persist
+
+## Benefits of This Migration
+
+✅ **Full Control**: Own your voice pipeline, no vendor lock-in
+✅ **Cost Effective**: Pay only for STT/TTS usage, no platform fees
+✅ **Customizable**: Modify dialog flow, add features easily
+✅ **Debuggable**: Full access to logs and metrics
+✅ **Scalable**: Deploy to edge, scale independently
+✅ **Reliable**: No third-party workflow dependencies
+
+## Next Steps
+
+- [ ] Deploy voice service to production
+- [ ] Update main app environment variables
+- [ ] Test end-to-end in production
+- [ ] Monitor logs and performance
+- [ ] (Optional) Add phone support via Twilio
+- [ ] (Optional) Add multi-language support
+- [ ] (Optional) Implement custom TTS voices
+
+## Rollback Plan
+
+If you need to rollback to Vapi:
+
+1. Uncomment Vapi env vars in `.env.local`
+2. In `components/Agent.tsx`, revert to using `vapi` import
+3. Restore original `handleCall` logic
+4. Redeploy
+
+The `/api/vapi/generate` endpoint is unchanged, so both systems can coexist during migration.

--- a/components/Agent.tsx
+++ b/components/Agent.tsx
@@ -5,8 +5,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 
 import { cn } from "@/lib/utils";
-import { vapi } from "@/lib/vapi.sdk";
-import { interviewer } from "@/constants";
+import { VoiceClient } from "@/lib/voice-client";
 import { createFeedback } from "@/lib/actions/general.action";
 
 enum CallStatus {
@@ -36,79 +35,16 @@ const Agent = ({
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [lastMessage, setLastMessage] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const [voiceClient, setVoiceClient] = useState<VoiceClient | null>(null);
 
   useEffect(() => {
-    const onCallStart = () => {
-      console.log("Call started successfully");
-      setCallStatus(CallStatus.ACTIVE);
-      setErrorMessage("");
-    };
-
-    const onCallEnd = (event?: any) => {
-      console.log("Call ended", event);
-      setCallStatus(CallStatus.FINISHED);
-      
-      // Check if it was an ejection
-      if (event?.type === "ejection" || event?.message?.includes("ejection")) {
-        console.error("Call was ejected:", event);
-        setErrorMessage("Call was disconnected unexpectedly. Please try again.");
-      }
-    };
-
-    const onMessage = (message: Message) => {
-      console.log("Received message:", message);
-      if (message.type === "transcript" && message.transcriptType === "final") {
-        const newMessage = { role: message.role, content: message.transcript };
-        setMessages((prev) => [...prev, newMessage]);
-      }
-    };
-
-    const onSpeechStart = () => {
-      console.log("Speech started");
-      setIsSpeaking(true);
-    };
-
-    const onSpeechEnd = () => {
-      console.log("Speech ended");
-      setIsSpeaking(false);
-    };
-
-    const onError = (error: Error) => {
-      console.error("Vapi error:", error);
-      setCallStatus(CallStatus.ERROR);
-      setErrorMessage(`Error: ${error.message}`);
-      
-      // Check for specific ejection errors
-      if (error.message.includes("ejection") || error.message.includes("ended")) {
-        setErrorMessage("Call was disconnected. Please try again.");
-      }
-    };
-
-    const onVolumeLevel = (volume: number) => {
-      // Optional: Handle volume levels for debugging
-      console.log("Volume level:", volume);
-    };
-
-    // Set up event listeners
-    vapi.on("call-start", onCallStart);
-    vapi.on("call-end", onCallEnd);
-    vapi.on("message", onMessage);
-    vapi.on("speech-start", onSpeechStart);
-    vapi.on("speech-end", onSpeechEnd);
-    vapi.on("error", onError);
-    vapi.on("volume-level", onVolumeLevel);
-
+    // Cleanup on unmount
     return () => {
-      // Clean up event listeners
-      vapi.off("call-start", onCallStart);
-      vapi.off("call-end", onCallEnd);
-      vapi.off("message", onMessage);
-      vapi.off("speech-start", onSpeechStart);
-      vapi.off("speech-end", onSpeechEnd);
-      vapi.off("error", onError);
-      vapi.off("volume-level", onVolumeLevel);
+      if (voiceClient) {
+        voiceClient.disconnect();
+      }
     };
-  }, []);
+  }, [voiceClient]);
 
   useEffect(() => {
     if (messages.length > 0) {
@@ -135,9 +71,10 @@ const Agent = ({
 
     if (callStatus === CallStatus.FINISHED) {
       if (type === "generate") {
-        router.push("/");
-        // Refresh the page to show the newly created interview
-        window.location.reload();
+        // Do not auto-navigate or refresh so errors/success messages remain visible.
+        // If you want to navigate after success, consider polling Firestore or
+        // having the workflow return a success signal, then navigate conditionally.
+        // e.g., setTimeout(() => router.push("/"), 3000)
       } else {
         handleGenerateFeedback(messages);
       }
@@ -150,38 +87,54 @@ const Agent = ({
       setCallStatus(CallStatus.CONNECTING);
       setErrorMessage("");
 
-      // Validate environment variables
-      if (!process.env.NEXT_PUBLIC_VAPI_WEB_TOKEN) {
-        throw new Error("Vapi web token not configured");
+      // Validate environment variable
+      const voiceServiceUrl = process.env.NEXT_PUBLIC_VOICE_SERVICE_URL;
+      if (!voiceServiceUrl) {
+        throw new Error("Voice service URL not configured. Set NEXT_PUBLIC_VOICE_SERVICE_URL in your environment.");
       }
 
-      if (type === "generate") {
-        if (!process.env.NEXT_PUBLIC_VAPI_WORKFLOW_ID) {
-          throw new Error("Vapi workflow ID not configured");
-        }
-        
-        console.log("Starting workflow call");
-        await vapi.start(process.env.NEXT_PUBLIC_VAPI_WORKFLOW_ID!, {
-          variableValues: {
-            username: userName,
-            userid: userId,
-          },
-        });
-      } else {
-        console.log("Starting interviewer call");
-        let formattedQuestions = "";
-        if (questions) {
-          formattedQuestions = questions
-            .map((question) => `- ${question}`)
-            .join("\n");
-        }
+      // Create voice client
+      const client = new VoiceClient({
+        url: voiceServiceUrl,
+        onTranscript: (transcript, role, isFinal) => {
+          if (isFinal) {
+            setMessages((prev) => [...prev, { role, content: transcript }]);
+          }
+        },
+        onPrompt: (content) => {
+          setIsSpeaking(true);
+          setTimeout(() => setIsSpeaking(false), 2000);
+        },
+        onError: (error) => {
+          console.error("Voice error:", error);
+          setErrorMessage(error);
+          setCallStatus(CallStatus.ERROR);
+        },
+        onDone: () => {
+          console.log("Call completed");
+          setCallStatus(CallStatus.FINISHED);
+        },
+        onConnectionChange: (connected) => {
+          if (connected) {
+            setCallStatus(CallStatus.ACTIVE);
+          }
+        },
+      });
 
-        await vapi.start(interviewer, {
-          variableValues: {
-            questions: formattedQuestions,
-          },
-        });
-      }
+      setVoiceClient(client);
+
+      // Connect to voice service
+      await client.connect(
+        userName,
+        userId!,
+        type === "generate" ? "generate" : "interview",
+        questions
+      );
+
+      // Start recording
+      await client.startRecording();
+
+      console.log("Call started successfully");
     } catch (error) {
       console.error("Error starting call:", error);
       setCallStatus(CallStatus.ERROR);
@@ -191,11 +144,17 @@ const Agent = ({
 
   const handleDisconnect = () => {
     console.log("Manually disconnecting call");
+    if (voiceClient) {
+      voiceClient.disconnect();
+    }
     setCallStatus(CallStatus.FINISHED);
-    vapi.stop();
   };
 
   const handleRetry = () => {
+    if (voiceClient) {
+      voiceClient.disconnect();
+      setVoiceClient(null);
+    }
     setCallStatus(CallStatus.INACTIVE);
     setErrorMessage("");
     setMessages([]);

--- a/env.example
+++ b/env.example
@@ -1,6 +1,9 @@
-# VAPI Configuration
-NEXT_PUBLIC_VAPI_WEB_TOKEN="your-vapi-web-token"
-NEXT_PUBLIC_VAPI_WORKFLOW_ID="your-vapi-workflow-id"
+# Voice Service Configuration (Go Microservice)
+NEXT_PUBLIC_VOICE_SERVICE_URL=ws://localhost:8080/voice
+
+# VAPI Configuration (Legacy - can be removed if fully migrated)
+# NEXT_PUBLIC_VAPI_WEB_TOKEN="your-vapi-web-token"
+# NEXT_PUBLIC_VAPI_WORKFLOW_ID="your-vapi-workflow-id"
 
 # Google AI Configuration
 GOOGLE_GENERATIVE_AI_API_KEY="your-google-ai-api-key"

--- a/lib/actions/general.action.ts
+++ b/lib/actions/general.action.ts
@@ -95,18 +95,34 @@ export async function getLatestInterviews(
 ): Promise<Interview[] | null> {
   const { userId, limit = 20 } = params;
 
-  const interviews = await db
+  // Fetch latest finalized interviews ordered by createdAt desc.
+  // Avoid Firestore inequality-ordering constraints by NOT using "!= userId" here.
+  // We'll exclude the current user's interviews in memory after fetching.
+  const snapshot = await db
     .collection("interviews")
-    .orderBy("createdAt", "desc")
     .where("finalized", "==", true)
-    .where("userId", "!=", userId)
-    .limit(limit)
+    .orderBy("createdAt", "desc")
+    // Slightly overfetch to compensate for client-side filtering of current user
+    .limit(limit * 2)
     .get();
 
-  return interviews.docs.map((doc) => ({
+  const all = snapshot.docs.map((doc) => ({
     id: doc.id,
     ...doc.data(),
   })) as Interview[];
+
+  // Filter out current user's interviews and cap to requested limit.
+  // If any legacy docs are missing createdAt, push them to the end deterministically.
+  const sanitized = all
+    .filter((i) => i.userId !== userId)
+    .sort((a, b) => {
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime; // desc
+    })
+    .slice(0, limit);
+
+  return sanitized;
 }
 
 export async function getInterviewsByUserId(

--- a/lib/voice-client.ts
+++ b/lib/voice-client.ts
@@ -1,0 +1,269 @@
+/**
+ * Voice Client for WebSocket communication with Go microservice
+ */
+
+export interface VoiceClientConfig {
+  url: string;
+  onTranscript?: (transcript: string, role: 'user' | 'assistant', isFinal: boolean) => void;
+  onPrompt?: (content: string) => void;
+  onAudio?: (audioData: ArrayBuffer) => void;
+  onError?: (error: string) => void;
+  onDone?: () => void;
+  onConnectionChange?: (connected: boolean) => void;
+}
+
+export class VoiceClient {
+  private ws: WebSocket | null = null;
+  private config: VoiceClientConfig;
+  private mediaRecorder: MediaRecorder | null = null;
+  private audioContext: AudioContext | null = null;
+  private processor: ScriptProcessorNode | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private isRecording = false;
+
+  constructor(config: VoiceClientConfig) {
+    this.config = config;
+  }
+
+  async connect(username: string, userid: string, mode: 'generate' | 'interview', questions?: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      try {
+        this.ws = new WebSocket(this.config.url);
+
+        this.ws.onopen = () => {
+          console.log('WebSocket connected');
+          this.config.onConnectionChange?.(true);
+
+          // Send start message
+          this.send({
+            type: 'start',
+            username,
+            userid,
+            mode,
+            questions,
+          });
+
+          resolve();
+        };
+
+        this.ws.onmessage = (event) => {
+          this.handleMessage(event.data);
+        };
+
+        this.ws.onerror = (error) => {
+          console.error('WebSocket error:', error);
+          this.config.onError?.('Connection error');
+          reject(error);
+        };
+
+        this.ws.onclose = () => {
+          console.log('WebSocket closed');
+          this.config.onConnectionChange?.(false);
+          this.stopRecording();
+        };
+      } catch (error) {
+        reject(error);
+      }
+    });
+  }
+
+  private handleMessage(data: string) {
+    try {
+      const message = JSON.parse(data);
+
+      switch (message.type) {
+        case 'transcript':
+          this.config.onTranscript?.(message.transcript, message.role, true);
+          break;
+
+        case 'transcript_partial':
+          this.config.onTranscript?.(message.transcript, message.role, false);
+          break;
+
+        case 'prompt':
+          this.config.onPrompt?.(message.content);
+          this.config.onTranscript?.(message.content, 'assistant', true);
+          break;
+
+        case 'audio':
+          if (message.audio) {
+            // Convert base64 or array to ArrayBuffer and play
+            const audioData = this.base64ToArrayBuffer(message.audio);
+            this.config.onAudio?.(audioData);
+            this.playAudio(audioData);
+          }
+          break;
+
+        case 'error':
+          this.config.onError?.(message.error);
+          break;
+
+        case 'done':
+          this.config.onDone?.();
+          break;
+
+        default:
+          console.log('Unknown message type:', message.type);
+      }
+    } catch (error) {
+      console.error('Failed to parse message:', error);
+    }
+  }
+
+  async startRecording(): Promise<void> {
+    if (this.isRecording) return;
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+        }
+      });
+
+      // Create audio context (use device sample rate, we will downsample to 16kHz)
+      this.audioContext = new AudioContext();
+      this.sourceNode = this.audioContext.createMediaStreamSource(stream);
+
+      // Create a ScriptProcessorNode for PCM capture
+      const bufferSize = 4096; // typical sizes: 1024, 2048, 4096
+      this.processor = this.audioContext.createScriptProcessor(bufferSize, 1, 1);
+
+      this.processor.onaudioprocess = (event) => {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        const inputBuffer = event.inputBuffer.getChannelData(0); // Float32 [-1, 1]
+
+        // Downsample to 16kHz if needed
+        const inputSampleRate = this.audioContext!.sampleRate;
+        const targetSampleRate = 16000;
+        const downsampled = this.downsampleBuffer(inputBuffer, inputSampleRate, targetSampleRate);
+
+        // Convert Float32 to 16-bit PCM
+        const pcm16 = this.floatTo16BitPCM(downsampled);
+
+        // Base64 encode and send
+        const b64 = this.arrayBufferToBase64(pcm16.buffer);
+        this.send({ type: 'audio', audio: b64 });
+      };
+
+      this.sourceNode.connect(this.processor);
+      this.processor.connect(this.audioContext.destination);
+
+      this.isRecording = true;
+      console.log('Recording started (PCM 16kHz)');
+    } catch (error) {
+      console.error('Failed to start recording:', error);
+      this.config.onError?.('Failed to access microphone');
+      throw error;
+    }
+  }
+
+  stopRecording(): void {
+    if (this.processor) {
+      this.processor.disconnect();
+      this.processor.onaudioprocess = null;
+      this.processor = null;
+    }
+    if (this.sourceNode) {
+      const stream = this.sourceNode.mediaStream;
+      stream.getTracks().forEach(t => t.stop());
+      this.sourceNode.disconnect();
+      this.sourceNode = null;
+    }
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = null;
+    }
+    this.isRecording = false;
+    console.log('Recording stopped');
+  }
+
+  disconnect(): void {
+    this.stopRecording();
+
+    if (this.ws) {
+      this.send({ type: 'stop' });
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  private send(data: any): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(data));
+    }
+  }
+
+  private base64ToArrayBuffer(base64: string): ArrayBuffer {
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes.buffer;
+  }
+
+  private arrayBufferToBase64(buffer: ArrayBufferLike): string {
+    let binary = '';
+    const bytes = new Uint8Array(buffer as ArrayBuffer);
+    const chunkSize = 0x8000;
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      const chunk = bytes.subarray(i, i + chunkSize);
+      binary += String.fromCharCode.apply(null as unknown as number[], Array.from(chunk));
+    }
+    return btoa(binary);
+  }
+
+  private downsampleBuffer(buffer: Float32Array, inputSampleRate: number, targetSampleRate: number): Float32Array {
+    if (targetSampleRate === inputSampleRate) {
+      return buffer;
+    }
+    const sampleRateRatio = inputSampleRate / targetSampleRate;
+    const newLength = Math.round(buffer.length / sampleRateRatio);
+    const result = new Float32Array(newLength);
+    let offsetResult = 0;
+    let offsetBuffer = 0;
+    while (offsetResult < result.length) {
+      const nextOffsetBuffer = Math.round((offsetResult + 1) * sampleRateRatio);
+      // simple averaging to reduce aliasing
+      let accum = 0, count = 0;
+      for (let i = offsetBuffer; i < nextOffsetBuffer && i < buffer.length; i++) {
+        accum += buffer[i];
+        count++;
+      }
+      result[offsetResult] = accum / (count || 1);
+      offsetResult++;
+      offsetBuffer = nextOffsetBuffer;
+    }
+    return result;
+  }
+
+  private floatTo16BitPCM(float32: Float32Array): Uint8Array {
+    const buffer = new ArrayBuffer(float32.length * 2);
+    const view = new DataView(buffer);
+    let offset = 0;
+    for (let i = 0; i < float32.length; i++, offset += 2) {
+      let s = Math.max(-1, Math.min(1, float32[i]));
+      view.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+    }
+    return new Uint8Array(buffer);
+  }
+
+  private async playAudio(audioData: ArrayBuffer): Promise<void> {
+    try {
+      const audioContext = new AudioContext();
+      const audioBuffer = await audioContext.decodeAudioData(audioData);
+      const source = audioContext.createBufferSource();
+      source.buffer = audioBuffer;
+      source.connect(audioContext.destination);
+      source.start(0);
+    } catch (error) {
+      console.error('Failed to play audio:', error);
+    }
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  experimental: {
-    serverComponentsExternalPackages: ["@adobe/pdfservices-node-sdk"],
-  },
+  serverExternalPackages: ["@adobe/pdfservices-node-sdk"],
   images: {
     domains: ["res.cloudinary.com"],
   },

--- a/pdf-server-deployment/pdf-server.js
+++ b/pdf-server-deployment/pdf-server.js
@@ -76,7 +76,7 @@ app.post('/extract-text', async (req, res) => {
     logMessage(`PDF downloaded successfully, size: ${pdfBuffer.length} bytes`);
     
     // Create a temporary file for the PDF
-    const tempDir = path.join(__dirname, "temp");
+    const tempDir = process.env.NODE_ENV === 'production' ? '/tmp' : path.join(__dirname, "temp");
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir, { recursive: true });
     }
@@ -241,7 +241,13 @@ app.post('/extract-text', async (req, res) => {
 
 // Health check endpoint
 app.get('/health', (req, res) => {
-  res.json({ status: 'OK', message: 'PDF extraction server is running' });
+  res.json({ 
+    status: 'OK', 
+    message: 'PDF extraction server is running',
+    environment: process.env.NODE_ENV || 'development',
+    tempDir: process.env.NODE_ENV === 'production' ? '/tmp' : path.join(__dirname, "temp"),
+    adobeConfigured: !!(process.env.ADOBE_CLIENT_ID && process.env.ADOBE_CLIENT_SECRET)
+  });
 });
 
 app.listen(PORT, () => {

--- a/voice-service/.gitignore
+++ b/voice-service/.gitignore
@@ -1,0 +1,25 @@
+# Binaries
+voice-service
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+*.out
+
+# Dependencies
+vendor/
+
+# Environment
+.env
+.env.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
+.DS_Store

--- a/voice-service/Dockerfile
+++ b/voice-service/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.21-alpine AS builder
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum* ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o voice-service .
+
+# Runtime image
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+COPY --from=builder /app/voice-service .
+
+EXPOSE 8080
+
+CMD ["./voice-service"]

--- a/voice-service/README.md
+++ b/voice-service/README.md
@@ -1,0 +1,246 @@
+# Voice Service (Go Microservice)
+
+WebSocket-based voice service for real-time interview generation using AssemblyAI (STT) and ElevenLabs (TTS).
+
+## Architecture
+
+```
+Browser (Agent.tsx)
+    ↓ WebSocket
+Voice Service (Go)
+    ├─ AssemblyAI (STT)
+    ├─ ElevenLabs (TTS)
+    └─ POST → Main App (/api/vapi/generate)
+```
+
+## Features
+
+- Real-time speech-to-text via AssemblyAI
+- Text-to-speech via ElevenLabs
+- Dialog state machine for collecting interview parameters
+- WebSocket communication with browser
+- Automatic interview generation via main app API
+
+## Setup
+
+### 1. Install Dependencies
+
+```bash
+cd voice-service
+go mod download
+```
+
+### 2. Configure Environment
+
+Copy `.env.example` to `.env` and fill in your API keys:
+
+```bash
+cp .env.example .env
+```
+
+Required variables:
+- `ASSEMBLYAI_API_KEY` - Get from https://www.assemblyai.com/
+- `ELEVENLABS_API_KEY` - Get from https://elevenlabs.io/
+- `ELEVENLABS_VOICE_ID` - Optional, defaults to Rachel voice
+- `MAIN_APP_URL` - Your main Next.js app URL
+- `ALLOWED_ORIGINS` - Comma-separated list of allowed CORS origins
+
+### 3. Run Locally
+
+```bash
+go run .
+```
+
+The service will start on `http://localhost:8080`
+
+## API Endpoints
+
+### Health Check
+```
+GET /health
+```
+
+Returns service status.
+
+### Voice WebSocket
+```
+WS /voice
+```
+
+WebSocket endpoint for voice sessions.
+
+## WebSocket Protocol
+
+### Client → Server Messages
+
+**Start Session:**
+```json
+{
+  "type": "start",
+  "username": "John Doe",
+  "userid": "firebase-user-id",
+  "mode": "generate"
+}
+```
+
+**Send Audio:**
+```json
+{
+  "type": "audio",
+  "audio": [base64-encoded-audio-bytes]
+}
+```
+
+**Stop Session:**
+```json
+{
+  "type": "stop"
+}
+```
+
+### Server → Client Messages
+
+**Transcript (Partial):**
+```json
+{
+  "type": "transcript_partial",
+  "transcript": "Hello...",
+  "role": "user"
+}
+```
+
+**Transcript (Final):**
+```json
+{
+  "type": "transcript",
+  "transcript": "Hello there",
+  "role": "user"
+}
+```
+
+**Prompt (Agent Speaking):**
+```json
+{
+  "type": "prompt",
+  "content": "What role would you like to train for?",
+  "role": "assistant"
+}
+```
+
+**Audio (TTS):**
+```json
+{
+  "type": "audio",
+  "audio": [mp3-audio-bytes]
+}
+```
+
+**Error:**
+```json
+{
+  "type": "error",
+  "error": "Error message"
+}
+```
+
+**Done:**
+```json
+{
+  "type": "done"
+}
+```
+
+## Dialog Flow (Generate Mode)
+
+1. **Ask Role**: "What role would you like to train for?"
+2. **Ask Type**: "Are you aiming for a technical, behavioral, or mixed interview?"
+3. **Ask Level**: "What is the job experience level required?"
+4. **Ask Tech Stack**: "What technologies should we cover?"
+5. **Ask Amount**: "How many questions would you like?"
+6. **Generate**: POST to main app `/api/vapi/generate`
+7. **Confirm**: "Your interview has been generated successfully!"
+
+## Deployment
+
+### Railway
+
+```bash
+railway login
+railway init
+railway up
+```
+
+### Fly.io
+
+```bash
+fly auth login
+fly launch
+fly deploy
+```
+
+### Docker
+
+```dockerfile
+FROM golang:1.21-alpine AS builder
+WORKDIR /app
+COPY go.* ./
+RUN go mod download
+COPY . .
+RUN go build -o voice-service .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=builder /app/voice-service .
+EXPOSE 8080
+CMD ["./voice-service"]
+```
+
+## Testing
+
+### Test Health Endpoint
+```bash
+curl http://localhost:8080/health
+```
+
+### Test WebSocket (using wscat)
+```bash
+npm install -g wscat
+wscat -c ws://localhost:8080/voice
+```
+
+Then send:
+```json
+{"type":"start","username":"Test User","userid":"test123","mode":"generate"}
+```
+
+## Troubleshooting
+
+### AssemblyAI Connection Issues
+- Verify API key is correct
+- Check network/firewall settings
+- Ensure sample rate is 16000 Hz
+
+### ElevenLabs TTS Issues
+- Verify API key and voice ID
+- Check API quota/limits
+- Try default voice ID if custom one fails
+
+### Main App Integration Issues
+- Verify MAIN_APP_URL is correct
+- Check CORS settings in ALLOWED_ORIGINS
+- Ensure /api/vapi/generate endpoint is accessible
+
+## Performance
+
+- Handles multiple concurrent WebSocket connections
+- Low-latency audio streaming
+- Efficient goroutine-based concurrency
+- Minimal memory footprint
+
+## Security
+
+- API keys stored server-side only
+- CORS validation on WebSocket upgrade
+- No sensitive data logged
+- Environment-based configuration

--- a/voice-service/deepgram.go
+++ b/voice-service/deepgram.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/gorilla/websocket"
+)
+
+type DeepgramClient struct {
+	conn         *websocket.Conn
+	onTranscript func(text string, isFinal bool)
+	mu           sync.Mutex
+	done         chan struct{}
+}
+
+func NewDeepgramClient(onTranscript func(string, bool)) (*DeepgramClient, error) {
+	apiKey := os.Getenv("DEEPGRAM_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("DEEPGRAM_API_KEY not set")
+	}
+
+	// Deepgram realtime endpoint. Using linear16 16kHz mono.
+	wsURL := "wss://api.deepgram.com/v1/listen?encoding=linear16&sample_rate=16000&channels=1&multichannel=false"
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Token "+apiKey)
+	headers.Set("User-Agent", "voice-service/1.0")
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, headers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to Deepgram: %w", err)
+	}
+
+	c := &DeepgramClient{
+		conn:         conn,
+		onTranscript: onTranscript,
+		done:         make(chan struct{}),
+	}
+
+	go c.readLoop()
+	log.Println("Deepgram client connected")
+	return c, nil
+}
+
+func (d *DeepgramClient) readLoop() {
+	defer close(d.done)
+	for {
+		_, message, err := d.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.Printf("Deepgram WebSocket error: %v", err)
+			}
+			return
+		}
+
+		// Deepgram messages are JSON; transcripts appear under channel.alternatives[0].transcript
+		var payload map[string]interface{}
+		if err := json.Unmarshal(message, &payload); err != nil {
+			log.Printf("Failed to parse Deepgram message: %v", err)
+			continue
+		}
+
+		isFinal, _ := payload["is_final"].(bool)
+		channel, _ := payload["channel"].(map[string]interface{})
+		if channel == nil {
+			continue
+		}
+		alts, _ := channel["alternatives"].([]interface{})
+		if len(alts) == 0 {
+			continue
+		}
+		first, _ := alts[0].(map[string]interface{})
+		text, _ := first["transcript"].(string)
+		if text != "" {
+			d.onTranscript(text, isFinal)
+		}
+	}
+}
+
+func (d *DeepgramClient) SendAudio(pcm []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Deepgram expects binary audio frames over WS
+	return d.conn.WriteMessage(websocket.BinaryMessage, pcm)
+}
+
+func (d *DeepgramClient) Close() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	_ = d.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	_ = d.conn.Close()
+	<-d.done
+	log.Println("Deepgram client closed")
+}

--- a/voice-service/dialog.go
+++ b/voice-service/dialog.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"log"
+	"strings"
+	"regexp"
+	"strconv"
+)
+
+type DialogState int
+
+const (
+	StateGreeting DialogState = iota
+	StateAskRole
+	StateAskType
+	StateAskLevel
+	StateAskTechStack
+	StateAskAmount
+	StateComplete
+)
+
+type DialogFields struct {
+	Username  string `json:"username"`
+	UserID    string `json:"userid"`
+	Role      string `json:"role"`
+	Type      string `json:"type"`
+	Level     string `json:"level"`
+	TechStack string `json:"techstack"`
+	Amount    string `json:"amount"`
+}
+
+type Dialog struct {
+	state      DialogState
+	fields     DialogFields
+	onComplete func(DialogFields)
+	nlu        NLU
+}
+
+func NewDialog(username, userid string, onComplete func(DialogFields), nlu NLU) *Dialog {
+	return &Dialog{
+		state: StateGreeting,
+		fields: DialogFields{
+			Username: username,
+			UserID:   userid,
+		},
+		onComplete: onComplete,
+		nlu:        nlu,
+	}
+}
+
+func (d *Dialog) Start(speak func(string)) {
+	d.state = StateAskRole
+	d.ask(speak)
+}
+
+func (d *Dialog) ProcessUserInput(input string, speak func(string)) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		speak("I didn't catch that. Could you please repeat?")
+		return
+	}
+
+	log.Printf("Dialog state: %d, input: %s", d.state, input)
+
+	switch d.state {
+	case StateAskRole:
+		if d.nlu != nil {
+			if val, err := d.nlu.ExtractField("role", input, d.fields); err == nil && strings.TrimSpace(val) != "" {
+				d.fields.Role = val
+			} else {
+				d.fields.Role = normalizeRole(input)
+			}
+		} else {
+			d.fields.Role = normalizeRole(input)
+		}
+		d.state = StateAskType
+		d.ask(speak)
+
+	case StateAskType:
+		// Heuristic: if user answered with a level instead, capture it and ask tech stack next
+		if lvl := detectLevel(input); lvl != "" {
+			d.fields.Level = lvl
+			if d.fields.Type == "" {
+				// Ask Type again since it was skipped
+				d.ask(speak)
+				d.state = StateAskType
+			} else {
+				d.state = StateAskTechStack
+				d.ask(speak)
+			}
+			return
+		}
+
+		if d.nlu != nil {
+			if val, err := d.nlu.ExtractField("type", input, d.fields); err == nil && strings.TrimSpace(val) != "" {
+				lower := strings.ToLower(val)
+				if lower == "technical" || lower == "behavioral" || lower == "mixed" {
+					d.fields.Type = lower
+				}
+			}
+		}
+		if d.fields.Type == "" {
+			if tp := detectType(input); tp != "" {
+				d.fields.Type = tp
+			} else {
+				// Ask to choose valid option
+				speak("Please choose one: technical, behavioral, or mixed.")
+				return
+			}
+		}
+		d.state = StateAskLevel
+		d.ask(speak)
+
+	case StateAskLevel:
+		// Heuristic: some users say 'technical' here; treat it as Type and re-ask level
+		if tp := detectType(input); tp != "" {
+			if d.fields.Type == "" {
+				d.fields.Type = tp
+			}
+			d.ask(speak)
+			d.state = StateAskLevel
+			return
+		}
+		if d.nlu != nil {
+			if val, err := d.nlu.ExtractField("level", input, d.fields); err == nil && strings.TrimSpace(val) != "" {
+				d.fields.Level = val
+			}
+		}
+		if d.fields.Level == "" {
+			if lvl := detectLevel(input); lvl != "" {
+				d.fields.Level = lvl
+			} else {
+				// keep original if cannot map but prompt examples
+				d.fields.Level = input
+			}
+		}
+		d.state = StateAskTechStack
+		d.ask(speak)
+
+	case StateAskTechStack:
+		if d.nlu != nil {
+			if val, err := d.nlu.ExtractField("techstack", input, d.fields); err == nil && strings.TrimSpace(val) != "" {
+				d.fields.TechStack = normalizeTechStack(val)
+			} else {
+				d.fields.TechStack = normalizeTechStack(input)
+			}
+		} else {
+			d.fields.TechStack = normalizeTechStack(input)
+		}
+		d.state = StateAskAmount
+		d.ask(speak)
+
+	case StateAskAmount:
+		if d.nlu != nil {
+			if val, err := d.nlu.ExtractField("amount", input, d.fields); err == nil && strings.TrimSpace(val) != "" {
+				d.fields.Amount = parseAmount(val)
+			} else {
+				d.fields.Amount = parseAmount(input)
+			}
+		} else {
+			d.fields.Amount = parseAmount(input)
+		}
+		d.state = StateComplete
+		speak("Perfect! I'm generating your personalized interview now. This will take a moment.")
+		
+		// Trigger completion
+		if d.onComplete != nil {
+			d.onComplete(d.fields)
+		}
+	}
+}
+
+// --- Helpers ---
+
+// ask generates a context-aware question via NLU with safe fallbacks
+func (d *Dialog) ask(speak func(string)) {
+    if d.nlu != nil {
+        if q, err := d.nlu.GenerateQuestion(d.state, d.fields); err == nil && strings.TrimSpace(q) != "" {
+            speak(q)
+            return
+        }
+    }
+    // Fallback prompts if NLU unavailable or errors
+    speak(d.fallbackQuestion())
+}
+
+func (d *Dialog) fallbackQuestion() string {
+    switch d.state {
+    case StateAskRole:
+        return "What role would you like to train for?"
+    case StateAskType:
+        return "Got it. Are you aiming for a technical, behavioral, or mixed interview?"
+    case StateAskLevel:
+        return "What is the job experience level required? For example: Intern, Junior, Mid, Senior, Staff, or Principal."
+    case StateAskTechStack:
+        return "What technologies or tech stack should we cover during the interview? You can say things like 'React, Next.js, Node.js'."
+    case StateAskAmount:
+        return "How many questions would you like me to prepare for you? (say a number like 5 or 10)"
+    default:
+        return "Could you clarify that?"
+    }
+}
+
+func normalizeRole(input string) string {
+	s := strings.TrimSpace(input)
+	s = strings.TrimPrefix(strings.ToLower(s), "a ")
+	s = strings.TrimPrefix(s, "an ")
+	s = strings.TrimPrefix(s, "the ")
+	// Remove leading phrases like "I want to train for", "for", etc.
+	s = strings.TrimPrefix(s, "i want to train for ")
+	s = strings.TrimPrefix(s, "train for ")
+	s = strings.TrimPrefix(s, "for ")
+	s = strings.TrimSpace(s)
+	// Title-case words
+	words := strings.Fields(s)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	out := strings.Join(words, " ")
+	if out == "" {
+		out = input
+	}
+	return out
+}
+
+func detectType(input string) string {
+	s := strings.ToLower(input)
+	switch {
+	case strings.Contains(s, "technical"):
+		return "technical"
+	case strings.Contains(s, "behavioral") || strings.Contains(s, "behavioural"):
+		return "behavioral"
+	case strings.Contains(s, "mixed") || strings.Contains(s, "both"):
+		return "mixed"
+	default:
+		return ""
+	}
+}
+
+func detectLevel(input string) string {
+	s := strings.ToLower(input)
+	levels := []string{"intern", "junior", "mid", "mid-level", "senior", "staff", "principal", "lead"}
+	for _, lvl := range levels {
+		if strings.Contains(s, lvl) {
+			if lvl == "mid-level" { return "Mid" }
+			return strings.Title(lvl)
+		}
+	}
+	// Heuristic: detect years like "2 years"; map to Mid for 2-4, Junior for 0-1, Senior 5+
+	re := regexp.MustCompile(`(\d+)\s*(year|years|yr|yrs)`) 
+	if m := re.FindStringSubmatch(s); len(m) == 3 {
+		if n, err := strconv.Atoi(m[1]); err == nil {
+			switch {
+			case n >= 5:
+				return "Senior"
+			case n >= 2:
+				return "Mid"
+			default:
+				return "Junior"
+			}
+		}
+	}
+	return ""
+}
+
+func normalizeTechStack(input string) string {
+	s := strings.ToLower(input)
+	// Replace connectors with commas
+	s = strings.NewReplacer(" and ", ",", ";", ",", "|", ",").Replace(s)
+	parts := strings.Split(s, ",")
+	cleaned := make([]string, 0, len(parts))
+	for _, p := range parts {
+		t := strings.TrimSpace(p)
+		if t == "" { continue }
+		// Title-case tech names roughly
+		words := strings.Fields(t)
+		for i, w := range words {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+		cleaned = append(cleaned, strings.Join(words, " "))
+	}
+	return strings.Join(cleaned, ", ")
+}
+
+func parseAmount(input string) string {
+	// Extract first integer; clamp between 1 and 20
+	re := regexp.MustCompile(`\d+`)
+	n := 10 // default
+	if m := re.FindString(input); m != "" {
+		if v, err := strconv.Atoi(m); err == nil {
+			n = v
+		}
+	}
+	if n < 1 { n = 1 }
+	if n > 20 { n = 20 }
+	return strconv.Itoa(n)
+}

--- a/voice-service/elevenlabs.go
+++ b/voice-service/elevenlabs.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type ElevenLabsClient struct {
+	apiKey  string
+	voiceID string
+	client  *http.Client
+}
+
+type ElevenLabsRequest struct {
+	Text          string                 `json:"text"`
+	ModelID       string                 `json:"model_id"`
+	VoiceSettings map[string]interface{} `json:"voice_settings"`
+}
+
+func NewElevenLabsClient() *ElevenLabsClient {
+	voiceID := os.Getenv("ELEVENLABS_VOICE_ID")
+	if voiceID == "" {
+		voiceID = "21m00Tcm4TlvDq8ikWAM" // Default voice (Rachel)
+	}
+
+	return &ElevenLabsClient{
+		apiKey:  os.Getenv("ELEVENLABS_API_KEY"),
+		voiceID: voiceID,
+		client:  &http.Client{},
+	}
+}
+
+func (c *ElevenLabsClient) Synthesize(text string) ([]byte, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("ELEVENLABS_API_KEY not set")
+	}
+
+	url := fmt.Sprintf("https://api.elevenlabs.io/v1/text-to-speech/%s", c.voiceID)
+
+	// Use a current model compatible with free tier; v1 models are deprecated for free tier.
+	// Options include: "eleven_turbo_v2" or "eleven_multilingual_v2".
+	reqBody := ElevenLabsRequest{
+		Text:    text,
+		ModelID: "eleven_turbo_v2",
+		VoiceSettings: map[string]interface{}{
+			"stability":        0.5,
+			"similarity_boost": 0.75,
+		},
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Accept", "audio/mpeg")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("xi-api-key", c.apiKey)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call ElevenLabs API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("ElevenLabs API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	audioData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read audio data: %w", err)
+	}
+
+	return audioData, nil
+}

--- a/voice-service/generate.go
+++ b/voice-service/generate.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type GenerateRequest struct {
+	Type      string `json:"type"`
+	Role      string `json:"role"`
+	Level     string `json:"level"`
+	TechStack string `json:"techstack"`
+	Amount    string `json:"amount"`
+	UserID    string `json:"userid"`
+}
+
+type GenerateResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func GenerateInterview(fields DialogFields) error {
+	mainAppURL := os.Getenv("MAIN_APP_URL")
+	endpoint := os.Getenv("MAIN_APP_GENERATE_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "/api/vapi/generate"
+	}
+
+	target := mainAppURL + endpoint
+
+	reqBody := GenerateRequest{
+		Type:      fields.Type,
+		Role:      fields.Role,
+		Level:     fields.Level,
+		TechStack: fields.TechStack,
+		Amount:    fields.Amount,
+		UserID:    fields.UserID,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	log.Printf("Generating interview via: %s", target)
+	req, err := http.NewRequest("POST", target, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Handle common local dev mistake: using https://localhost against an http dev server
+		if strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") || strings.Contains(err.Error(), "tls:") {
+			if parsed, pErr := url.Parse(target); pErr == nil {
+				if parsed.Scheme == "https" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1") {
+					parsed.Scheme = "http"
+					fallback := parsed.String()
+					log.Printf("HTTPS failed against localhost, retrying over HTTP: %s", fallback)
+					req2, r2 := http.NewRequest("POST", fallback, bytes.NewBuffer(jsonData))
+					if r2 == nil {
+						req2.Header.Set("Content-Type", "application/json")
+						resp2, e2 := client.Do(req2)
+						if e2 == nil {
+							resp = resp2
+							err = nil
+						} else {
+							return fmt.Errorf("failed to call generate API (retry http): %w", e2)
+						}
+					} else {
+						return fmt.Errorf("failed to create retry request: %w", r2)
+					}
+				} else {
+					return fmt.Errorf("failed to call generate API: %w", err)
+				}
+			} else {
+				return fmt.Errorf("failed to parse URL for retry: %w", pErr)
+			}
+		} else {
+			return fmt.Errorf("failed to call generate API: %w", err)
+		}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var result GenerateResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !result.Success {
+		return fmt.Errorf("generate API error: %s", result.Error)
+	}
+
+	return nil
+}

--- a/voice-service/go.mod
+++ b/voice-service/go.mod
@@ -1,0 +1,10 @@
+module voice-service
+
+go 1.21
+
+require (
+	github.com/gorilla/websocket v1.5.1
+	github.com/joho/godotenv v1.5.1
+)
+
+require golang.org/x/net v0.17.0 // indirect

--- a/voice-service/go.sum
+++ b/voice-service/go.sum
@@ -1,0 +1,6 @@
+github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
+github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=

--- a/voice-service/main.go
+++ b/voice-service/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/gorilla/websocket"
+	"github.com/joho/godotenv"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		allowedOrigins := strings.Split(os.Getenv("ALLOWED_ORIGINS"), ",")
+		for _, allowed := range allowedOrigins {
+			if strings.TrimSpace(allowed) == origin {
+				return true
+			}
+		}
+		return false
+	},
+}
+
+func main() {
+	// Load environment variables
+	if err := godotenv.Load(); err != nil {
+		log.Println("No .env file found, using system environment variables")
+	}
+
+	// Validate required environment variables
+	required := []string{"ELEVENLABS_API_KEY", "MAIN_APP_URL"}
+	for _, key := range required {
+		if os.Getenv(key) == "" {
+			log.Fatalf("Missing required environment variable: %s", key)
+		}
+	}
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	http.HandleFunc("/health", healthHandler)
+	http.HandleFunc("/voice", voiceHandler)
+
+	log.Printf("Voice service starting on port %s", port)
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok","service":"voice-service"}`))
+}
+
+func voiceHandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Printf("WebSocket upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	log.Println("New WebSocket connection established")
+
+	// Create a new session for this connection
+	session := NewSession(conn)
+	session.Start()
+}

--- a/voice-service/nlu.go
+++ b/voice-service/nlu.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// NLU provides question generation and field normalization
+type NLU interface {
+	GenerateQuestion(state DialogState, fields DialogFields) (string, error)
+	ExtractField(expected string, utterance string, fields DialogFields) (string, error)
+}
+
+// OpenAINLU implements NLU using OpenAI Chat Completions
+type OpenAINLU struct {
+	apiKey string
+	model  string
+}
+
+func NewOpenAINLU() *OpenAINLU {
+	model := os.Getenv("OPENAI_MODEL")
+	if model == "" {
+		model = "gpt-4o-mini"
+	}
+	return &OpenAINLU{
+		apiKey: os.Getenv("OPENAI_API_KEY"),
+		model:  model,
+	}
+}
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIRequest struct {
+	Model       string          `json:"model"`
+	Messages    []openAIMessage `json:"messages"`
+	Temperature float32         `json:"temperature,omitempty"`
+}
+
+type openAIChoice struct {
+	Message struct {
+		Content string `json:"content"`
+	} `json:"message"`
+}
+
+type openAIResponse struct {
+	Choices []openAIChoice `json:"choices"`
+}
+
+func (o *OpenAINLU) chat(system, user string) (string, error) {
+	if o.apiKey == "" {
+		return "", fmt.Errorf("OPENAI_API_KEY not set")
+	}
+	body := openAIRequest{
+		Model: o.model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: system},
+			{Role: "user", Content: user},
+		},
+		Temperature: 0.2,
+	}
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", bytes.NewBuffer(data))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("openai error: %s", string(b))
+	}
+	var out openAIResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return "", err
+	}
+	if len(out.Choices) == 0 {
+		return "", fmt.Errorf("no choices")
+	}
+	return strings.TrimSpace(out.Choices[0].Message.Content), nil
+}
+
+func (o *OpenAINLU) GenerateQuestion(state DialogState, fields DialogFields) (string, error) {
+	system := "You generate concise, friendly one-sentence questions to collect interview setup fields. Keep it under 18 words."
+	want := ""
+	switch state {
+	case StateAskRole:
+		want = "Ask for the target role/title the user wants to train for."
+	case StateAskType:
+		want = "Ask whether the interview should be technical, behavioral, or mixed (offer those three options)."
+	case StateAskLevel:
+		want = "Ask the experience level (Intern, Junior, Mid, Senior, Staff, Principal, or Lead)."
+	case StateAskTechStack:
+		want = "Ask for technologies/stack to focus on, with examples like React, Next.js, Node.js."
+	case StateAskAmount:
+		want = "Ask how many questions to prepare (a number like 5 or 10)."
+	default:
+		want = "Ask a clarifying question."
+	}
+	user := fmt.Sprintf("Known fields: %+v\nGenerate question: %s", fields, want)
+	return o.chat(system, user)
+}
+
+func (o *OpenAINLU) ExtractField(expected string, utterance string, fields DialogFields) (string, error) {
+	system := "You extract a SINGLE field value in a strict, normalized form. Return ONLY the value, no extra words.\nType must be one of: technical, behavioral, mixed. Level must be one of: Intern, Junior, Mid, Senior, Staff, Principal, Lead. Amount must be an integer 1-20. Techstack should be a comma-separated list of technologies in Title Case. Role is a concise title in Title Case."
+	user := fmt.Sprintf("Expected field: %s\nUser said: %s\nKnown fields: %+v", expected, utterance, fields)
+	val, err := o.chat(system, user)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(val), nil
+}

--- a/voice-service/session.go
+++ b/voice-service/session.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"encoding/base64"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type SessionMode string
+
+const (
+	ModeGenerate  SessionMode = "generate"
+	ModeInterview SessionMode = "interview"
+)
+
+type Session struct {
+	conn         *websocket.Conn
+	username     string
+	userid       string
+	mode         SessionMode
+	dialog       *Dialog
+	sttClient    STTClient
+	ttsClient    *ElevenLabsClient
+	audioBuffer  chan []byte
+	done         chan struct{}
+	mu           sync.Mutex
+	isActive     bool
+}
+
+// STTClient abstracts the speech-to-text streaming client.
+type STTClient interface {
+	SendAudio([]byte) error
+	Close()
+}
+
+type ClientMessage struct {
+	Type      string    `json:"type"`
+	Username  string    `json:"username,omitempty"`
+	UserID    string    `json:"userid,omitempty"`
+	Mode      string    `json:"mode,omitempty"`
+	Audio     string    `json:"audio,omitempty"` // base64-encoded audio from browser
+	Questions []string  `json:"questions,omitempty"`
+}
+
+type ServerMessage struct {
+	Type       string `json:"type"`
+	Content    string `json:"content,omitempty"`
+	Role       string `json:"role,omitempty"`
+	Transcript string `json:"transcript,omitempty"`
+	Audio      []byte `json:"audio,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
+func NewSession(conn *websocket.Conn) *Session {
+	return &Session{
+		conn:        conn,
+		audioBuffer: make(chan []byte, 100),
+		done:        make(chan struct{}),
+		isActive:    false,
+	}
+}
+
+func (s *Session) Start() {
+	defer func() {
+		// Cleanup resources; do NOT close(s.done) here to avoid double close.
+		s.cleanup()
+	}()
+
+	// Read initial start message
+	var startMsg ClientMessage
+	if err := s.conn.ReadJSON(&startMsg); err != nil {
+		log.Printf("Failed to read start message: %v", err)
+		s.sendError("Failed to read start message")
+		return
+	}
+
+	if startMsg.Type != "start" {
+		s.sendError("Expected 'start' message")
+		return
+	}
+
+	s.username = startMsg.Username
+	s.userid = startMsg.UserID
+	s.mode = SessionMode(startMsg.Mode)
+
+	log.Printf("Session started: user=%s, userid=%s, mode=%s", s.username, s.userid, s.mode)
+
+	// Initialize STT client (Deepgram)
+	var err error
+	s.sttClient, err = NewDeepgramClient(s.onTranscript)
+	if err != nil {
+		log.Printf("Failed to create Deepgram client: %v", err)
+		s.sendError("Failed to initialize speech recognition")
+		return
+	}
+
+	s.ttsClient = NewElevenLabsClient()
+
+	// Initialize dialog based on mode
+	if s.mode == ModeGenerate {
+		// Create NLU (OpenAI) for AI-framed questions if key is present
+		var nlu NLU
+		if os.Getenv("OPENAI_API_KEY") != "" {
+			nlu = NewOpenAINLU()
+		}
+		s.dialog = NewDialog(s.username, s.userid, s.onDialogComplete, nlu)
+	}
+
+	s.isActive = true
+
+	// Start listening for audio and messages
+	go s.readMessages()
+	go s.processAudio()
+
+	// Start the dialog
+	if s.mode == ModeGenerate {
+		s.dialog.Start(s.speak)
+	} else {
+		// For interview mode, just start listening
+		s.speak("Hello " + s.username + ". I'm ready to conduct your interview. Please answer each question clearly.")
+	}
+
+	// Wait for completion
+	<-s.done
+}
+
+func (s *Session) readMessages() {
+	defer func() {
+		s.isActive = false
+		// Close done channel once to signal end of session
+		select {
+		case <-s.done:
+			// already closed
+		default:
+			close(s.done)
+		}
+	}()
+
+	for {
+		var msg ClientMessage
+		if err := s.conn.ReadJSON(&msg); err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+				log.Printf("WebSocket error: %v", err)
+			}
+			return
+		}
+
+		switch msg.Type {
+		case "audio":
+			if msg.Audio != "" {
+				// Decode base64 audio string to raw bytes before enqueueing
+				decoded, err := base64.StdEncoding.DecodeString(msg.Audio)
+				if err != nil {
+					log.Printf("Failed to decode base64 audio: %v", err)
+					break
+				}
+				select {
+				case s.audioBuffer <- decoded:
+				default:
+					log.Println("Audio buffer full, dropping packet")
+				}
+			}
+		case "stop":
+			log.Println("Client requested stop")
+			return
+		}
+	}
+}
+
+func (s *Session) processAudio() {
+	for {
+		select {
+		case audio := <-s.audioBuffer:
+			if s.sttClient != nil && s.isActive {
+				if err := s.sttClient.SendAudio(audio); err != nil {
+					log.Printf("Failed to send audio to STT: %v", err)
+					// If STT socket is closed, stop processing further audio
+					if strings.Contains(err.Error(), "close") {
+						return
+					}
+				}
+			}
+		case <-s.done:
+			return
+		}
+	}
+}
+
+func (s *Session) onTranscript(transcript string, isFinal bool) {
+	if !isFinal {
+		// Send partial transcript for display
+		s.sendMessage(ServerMessage{
+			Type:       "transcript_partial",
+			Transcript: transcript,
+			Role:       "user",
+		})
+		return
+	}
+
+	// Send final transcript
+	s.sendMessage(ServerMessage{
+		Type:       "transcript",
+		Transcript: transcript,
+		Role:       "user",
+	})
+
+	// Process based on mode
+	if s.mode == ModeGenerate && s.dialog != nil {
+		s.dialog.ProcessUserInput(transcript, s.speak)
+	}
+}
+
+func (s *Session) onDialogComplete(fields DialogFields) {
+	log.Printf("Dialog complete: %+v", fields)
+
+	// Call main app to generate interview
+	go func() {
+		if err := GenerateInterview(fields); err != nil {
+			log.Printf("Failed to generate interview: %v", err)
+			s.speak("I'm sorry, there was an error generating your interview. Please try again.")
+			s.sendError(err.Error())
+		} else {
+			s.speak("Perfect! Your interview has been generated successfully. You can check your dashboard now. Thank you!")
+			time.Sleep(2 * time.Second)
+			s.sendMessage(ServerMessage{Type: "done"})
+		}
+	}()
+}
+
+func (s *Session) speak(text string) {
+	log.Printf("Speaking: %s", text)
+
+	// Send text to client for display
+	s.sendMessage(ServerMessage{
+		Type:    "prompt",
+		Content: text,
+		Role:    "assistant",
+	})
+
+	// Generate and stream TTS audio
+	if s.ttsClient != nil {
+		audioData, err := s.ttsClient.Synthesize(text)
+		if err != nil {
+			log.Printf("TTS error: %v", err)
+			return
+		}
+
+		// Send audio to client
+		s.sendMessage(ServerMessage{
+			Type:  "audio",
+			Audio: audioData,
+		})
+	}
+}
+
+func (s *Session) sendMessage(msg ServerMessage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.conn.WriteJSON(msg); err != nil {
+		log.Printf("Failed to send message: %v", err)
+	}
+}
+
+func (s *Session) sendError(errMsg string) {
+	s.sendMessage(ServerMessage{
+		Type:  "error",
+		Error: errMsg,
+	})
+}
+
+func (s *Session) cleanup() {
+	log.Println("Cleaning up session")
+
+	if s.sttClient != nil {
+		s.sttClient.Close()
+	}
+
+	s.conn.Close()
+}


### PR DESCRIPTION
**Add Go Voice Microservice + Next.js Integration**

This PR replaces the Vapi-based voice flow with a lightweight Go voice microservice and updates the Next.js app to use it.

**Summary**

Adds a standalone Go WebSocket voice service that:

- Streams 16 kHz PCM audio → Deepgram (real-time STT)

- Returns ElevenLabs audio (TTS)

- Runs a dialog to collect: role, type, level, tech stack, amount

- Optionally uses OpenAI for better question phrasing & field normalization

- Calls existing Next.js endpoint /api/vapi/generate

Next.js integrates via a new browser client:

- Captures mic → sends PCM → plays TTS replies

- Replaces Vapi in Agent.tsx

- Goal: fully own the voice pipeline, improve accuracy/UX, and scale independently.

**Backend (New: voice-service/)**

Key components:

- main.go – WebSocket server (/voice), health check, origin restrictions
- session.go – session lifecycle, STT/TTS loop
- deepgram.go – 16 kHz PCM → Deepgram
- elevenlabs.go – TTS (eleven_turbo_v2)
- dialog.go – dialog FSM
- nlu.go – optional OpenAI question/field normalization
- generate.go – calls MAIN_APP_URL + /api/vapi/generate

**Frontend Changes**

**New: lib/voice-client.ts**

- WebSocket client + mic capture

- Downsamples to 16 kHz

- Sends PCM over WS

- Plays ElevenLabs audio

**Updated: components/Agent.tsx**

- Replaces Vapi usage

- Tracks call status, transcripts, messages

- Generates interview when dialog completes