### PR TITLE
Add User Dashboard with Analytics and Profile Editing

### DIFF
--- a/app/(root)/dashboard/page.tsx
+++ b/app/(root)/dashboard/page.tsx
@@ -1,0 +1,196 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowLeft } from "lucide-react";
+import { getCurrentUser } from "@/lib/actions/auth.action";
+import { getUserDashboardStats, getPeerAverages, getInterviewsByUserId } from "@/lib/actions/general.action";
+import DashboardStats from "@/components/DashboardStats";
+import UserProfileCard from "@/components/UserProfileCard";
+import PerformanceChart from "@/components/PerformanceChart";
+import CategoryScoresChart from "@/components/CategoryScoresChart";
+import CategoryBreakdown from "@/components/CategoryBreakdown";
+import InterviewTypeDistribution from "@/components/InterviewTypeDistribution";
+import RecentInterviews from "@/components/RecentInterviews";
+import LogoutButton from "@/components/LogoutButton";
+
+export default async function DashboardPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const [userStats, peerStats, userInterviews] = await Promise.all([
+    getUserDashboardStats(user.id),
+    getPeerAverages(),
+    getInterviewsByUserId(user.id),
+  ]);
+
+  if (!userStats) {
+    return (
+      <div className="w-full flex flex-col gap-8">
+        <p className="text-light-100">Failed to load dashboard data.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Navigation */}
+      <nav className="flex justify-between items-center p-4">
+        <Link href="/" className="flex items-center gap-2">
+          <Image src="/logo.svg" alt="Evalia Logo" width={38} height={32} />
+          <h2 className="text-primary-100 text-2xl font-bold">Evalia</h2>
+        </Link>
+        {user && (
+          <div className="flex items-center gap-4">
+            <div className="hidden md:flex items-center gap-2">
+              <div className="w-8 h-8 rounded-full bg-primary-100 flex items-center justify-center">
+                {user.name?.charAt(0) || "U"}
+              </div>
+              <span className="text-light-100">{user.name || "User"}</span>
+            </div>
+            <LogoutButton />
+          </div>
+        )}
+      </nav>
+
+      <div className="root-layout">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <Link 
+              href="/" 
+              className="flex items-center gap-2 text-light-100/70 hover:text-primary-100 transition-colors mb-4"
+            >
+              <ArrowLeft size={20} />
+              <span>Back to Home</span>
+            </Link>
+            <h1 className="text-4xl font-bold bg-gradient-to-r from-primary-100 to-primary-200 bg-clip-text text-transparent">
+              Your Dashboard
+            </h1>
+            <p className="text-light-100/70 mt-2">
+              Track your progress and compare with peers
+            </p>
+          </div>
+        </div>
+
+        {/* Statistics Cards */}
+        <DashboardStats
+          interviewsCreated={userStats.interviewsCreated}
+          interviewsTaken={userStats.interviewsTaken}
+          averageScore={userStats.averageScore}
+          peerAverage={peerStats.averageScore}
+        />
+
+        {/* Profile, Recent Interviews, and Interview Types */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-8 items-stretch">
+          <UserProfileCard user={user} />
+          <RecentInterviews 
+            interviews={userStats.allFeedbacks} 
+            title="Recent Interviews"
+          />
+          <InterviewTypeDistribution interviews={userInterviews || []} />
+        </div>
+
+        {/* Charts Section */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">
+          <PerformanceChart data={userStats.recentFeedbacks} />
+          <CategoryScoresChart 
+            userScores={userStats.categoryAverages}
+            peerScores={peerStats.categoryAverages}
+          />
+        </div>
+
+        {/* Category Breakdown */}
+        {Object.keys(userStats.categoryAverages).length > 0 && (
+          <div className="mt-8">
+            <CategoryBreakdown categories={userStats.categoryAverages} />
+          </div>
+        )}
+
+        {/* Insights Section */}
+        {userStats.interviewsTaken > 0 && (
+          <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 mt-8 overflow-hidden">
+            <h3 className="text-xl font-semibold text-light-100 mb-4">Your Insights</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div className="bg-dark-300/50 rounded-lg p-4 overflow-hidden">
+                <p className="text-light-100/70 text-sm mb-2">Performance Trend</p>
+                <p className="text-light-100 text-lg font-semibold break-words">
+                  {userStats.recentFeedbacks.length >= 2 ? (
+                    userStats.recentFeedbacks[userStats.recentFeedbacks.length - 1].totalScore >
+                    userStats.recentFeedbacks[userStats.recentFeedbacks.length - 2].totalScore ? (
+                      <span className="text-success-100">📈 Improving</span>
+                    ) : (
+                      <span className="text-primary-100">📊 Stable</span>
+                    )
+                  ) : (
+                    <span className="text-primary-100">🎯 Getting Started</span>
+                  )}
+                </p>
+              </div>
+
+              <div className="bg-dark-300/50 rounded-lg p-4 overflow-hidden">
+                <p className="text-light-100/70 text-sm mb-2">vs Peers</p>
+                <p className="text-light-100 text-lg font-semibold break-words">
+                  {userStats.averageScore > peerStats.averageScore ? (
+                    <span className="text-success-100">🏆 Above Average</span>
+                  ) : userStats.averageScore === peerStats.averageScore ? (
+                    <span className="text-primary-100">🎯 On Par</span>
+                  ) : (
+                    <span className="text-primary-200">💪 Room to Grow</span>
+                  )}
+                </p>
+              </div>
+
+              <div className="bg-dark-300/50 rounded-lg p-4 overflow-hidden">
+                <p className="text-light-100/70 text-sm mb-2">Best Category</p>
+                <p className="text-light-100 text-lg font-semibold break-words">
+                  {Object.keys(userStats.categoryAverages).length > 0 ? (
+                    <span className="text-primary-100">
+                      {Object.entries(userStats.categoryAverages).reduce((a, b) => 
+                        a[1] > b[1] ? a : b
+                      )[0].replace(' Skills', '')}
+                    </span>
+                  ) : (
+                    <span className="text-light-100/70">N/A</span>
+                  )}
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Call to Action */}
+        {userStats.interviewsTaken === 0 && (
+          <div className="card-cta mt-8 overflow-hidden">
+            <div className="flex flex-col gap-4 max-w-lg z-10">
+              <h3 className="text-2xl font-bold text-primary-100 break-words">
+                Ready to Start Your Journey?
+              </h3>
+              <p className="text-light-100 break-words">
+                Take your first interview to see detailed analytics and track your progress over time.
+              </p>
+              <Link href="/" className="btn-primary w-fit">
+                Browse Interviews
+              </Link>
+            </div>
+            <Image
+              src="/robot.png"
+              alt="AI Interview Assistant"
+              width={300}
+              height={300}
+              className="max-sm:hidden z-10 flex-shrink-0"
+            />
+          </div>
+        )}
+      </div>
+
+      <footer className="mt-16 py-6 border-t border-dark-200 text-center text-light-100/50">
+        <div className="container mx-auto">
+          <p>© 2025 Evalia. All rights reserved.</p>
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/app/(root)/interview/[id]/feedback/page.tsx
+++ b/app/(root)/interview/[id]/feedback/page.tsx
@@ -27,7 +27,7 @@ const Feedback = async ({ params }: RouteParams) => {
     <div className="max-w-4xl mx-auto px-4 py-8">
       {/* Header Section */}
       <div className="mb-8">
-        <Link href="/" className="inline-flex items-center text-primary-200 hover:underline mb-4">
+        <Link href="/dashboard" className="inline-flex items-center text-primary-200 hover:underline mb-4">
           <ArrowLeft className="mr-2" size={18} /> Back to Dashboard
         </Link>
         
@@ -146,7 +146,7 @@ const Feedback = async ({ params }: RouteParams) => {
       {/* Action Buttons */}
       <div className="flex flex-col sm:flex-row gap-4">
         <Button asChild className="btn-secondary flex-1 hover:scale-[1.02] transition-transform">
-          <Link href="/" className="flex items-center justify-center gap-2">
+          <Link href="/dashboard" className="flex items-center justify-center gap-2">
             <ArrowLeft size={18} /> Back to Dashboard
           </Link>
         </Button>

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import FilteredInterviewsSection from "@/components/FilteredInterviewsSection";
-import { Mic2, Sparkles, BarChart2, Clock, Users, FileText, Upload } from "lucide-react";
+import { Mic2, Sparkles, BarChart2, Clock, Users, FileText, Upload, LayoutDashboard } from "lucide-react";
 import { getCurrentUser } from "@/lib/actions/auth.action";
 import {
   getInterviewsByUserId,
@@ -30,6 +30,12 @@ async function Home() {
         </Link>
         {user && (
           <div className="flex items-center gap-4">
+            <Button asChild className="btn-secondary !min-h-9">
+              <Link href="/dashboard" className="flex items-center gap-2">
+                <LayoutDashboard size={18} />
+                <span className="max-sm:hidden">Dashboard</span>
+              </Link>
+            </Button>
             <div className="hidden md:flex items-center gap-2">
               <div className="w-8 h-8 rounded-full bg-primary-100 flex items-center justify-center">
                 {user.name?.charAt(0) || "U"}

--- a/components/CategoryBreakdown.tsx
+++ b/components/CategoryBreakdown.tsx
@@ -1,0 +1,57 @@
+interface CategoryBreakdownProps {
+  categories: { [key: string]: number };
+}
+
+export default function CategoryBreakdown({ categories }: CategoryBreakdownProps) {
+  const categoryList = Object.entries(categories).map(([name, score]) => ({
+    name,
+    score,
+  }));
+
+  const getScoreColor = (score: number) => {
+    if (score >= 80) return 'bg-success-100';
+    if (score >= 60) return 'bg-primary-100';
+    if (score >= 40) return 'bg-primary-200';
+    return 'bg-light-400';
+  };
+
+  const getScoreTextColor = (score: number) => {
+    if (score >= 80) return 'text-success-100';
+    if (score >= 60) return 'text-primary-100';
+    if (score >= 40) return 'text-primary-200';
+    return 'text-light-400';
+  };
+
+  return (
+    <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 overflow-hidden">
+      <h3 className="text-xl font-semibold text-light-100 mb-6">Category Breakdown</h3>
+      
+      {categoryList.length > 0 ? (
+        <div className="space-y-4">
+          {categoryList.map(({ name, score }) => (
+            <div key={name}>
+              <div className="flex items-center justify-between mb-2 gap-4">
+                <span className="text-light-100 text-sm font-medium break-words flex-1">
+                  {name}
+                </span>
+                <span className={`text-sm font-bold ${getScoreTextColor(score)} whitespace-nowrap`}>
+                  {score}/100
+                </span>
+              </div>
+              <div className="w-full bg-dark-300 rounded-full h-2.5 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all duration-500 ${getScoreColor(score)}`}
+                  style={{ width: `${score}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-8">
+          <p className="text-light-100/70">No category data available yet.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/CategoryScoresChart.tsx
+++ b/components/CategoryScoresChart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { RadarChart, PolarGrid, PolarAngleAxis, PolarRadiusAxis, Radar, Legend, ResponsiveContainer, Tooltip } from 'recharts';
+
+interface CategoryScoresChartProps {
+  userScores: { [key: string]: number };
+  peerScores: { [key: string]: number };
+}
+
+export default function CategoryScoresChart({ userScores, peerScores }: CategoryScoresChartProps) {
+  const chartData = Object.keys(userScores).map((category) => ({
+    category: category.replace(' Skills', '').replace(' and ', ' & '),
+    you: userScores[category] || 0,
+    peers: peerScores[category] || 0,
+  }));
+
+  return (
+    <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 overflow-hidden">
+      <h3 className="text-xl font-semibold text-light-100 mb-6">Skills Comparison</h3>
+      {chartData.length > 0 ? (
+        <div className="w-full" style={{ height: '350px' }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <RadarChart data={chartData} margin={{ top: 20, right: 30, bottom: 20, left: 30 }}>
+              <PolarGrid stroke="#27282f" />
+              <PolarAngleAxis 
+                dataKey="category" 
+                stroke="#d6e0ff"
+                style={{ fontSize: '11px' }}
+                tick={{ fill: '#d6e0ff' }}
+              />
+              <PolarRadiusAxis 
+                angle={90} 
+                domain={[0, 100]}
+                tick={false}
+              />
+              <Radar 
+                name="You" 
+                dataKey="you" 
+                stroke="#dddfff" 
+                fill="#dddfff" 
+                fillOpacity={0.6}
+                strokeWidth={2}
+              />
+              <Radar 
+                name="Peers Average" 
+                dataKey="peers" 
+                stroke="#6870a6" 
+                fill="#6870a6" 
+                fillOpacity={0.3}
+                strokeWidth={2}
+              />
+              <Legend 
+                wrapperStyle={{ color: '#d6e0ff' }}
+              />
+              <Tooltip 
+                contentStyle={{ 
+                  backgroundColor: '#27282f', 
+                  border: '1px solid #dddfff',
+                  borderRadius: '8px',
+                  color: '#d6e0ff'
+                }}
+              />
+            </RadarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="h-[350px] flex items-center justify-center px-4">
+          <p className="text-light-100/70 text-center">No category data available yet.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/DashboardStats.tsx
+++ b/components/DashboardStats.tsx
@@ -1,0 +1,73 @@
+import { FileText, CheckCircle, TrendingUp, Users } from "lucide-react";
+
+interface DashboardStatsProps {
+  interviewsCreated: number;
+  interviewsTaken: number;
+  averageScore: number;
+  peerAverage: number;
+}
+
+export default function DashboardStats({ 
+  interviewsCreated, 
+  interviewsTaken, 
+  averageScore,
+  peerAverage 
+}: DashboardStatsProps) {
+  const scoreDiff = averageScore - peerAverage;
+  const isAboveAverage = scoreDiff > 0;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      {/* Interviews Created */}
+      <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 hover:border-primary-100/30 transition-all hover:scale-105">
+        <div className="flex items-center justify-between mb-4">
+          <div className="w-12 h-12 rounded-xl bg-primary-100/20 flex items-center justify-center text-primary-100">
+            <FileText size={24} />
+          </div>
+        </div>
+        <p className="text-3xl font-bold text-primary-100">{interviewsCreated}</p>
+        <p className="text-light-100/70 mt-1">Interviews Created</p>
+      </div>
+
+      {/* Interviews Taken */}
+      <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 hover:border-primary-100/30 transition-all hover:scale-105">
+        <div className="flex items-center justify-between mb-4">
+          <div className="w-12 h-12 rounded-xl bg-success-100/20 flex items-center justify-center text-success-100">
+            <CheckCircle size={24} />
+          </div>
+        </div>
+        <p className="text-3xl font-bold text-success-100">{interviewsTaken}</p>
+        <p className="text-light-100/70 mt-1">Interviews Taken</p>
+      </div>
+
+      {/* Average Score */}
+      <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 hover:border-primary-100/30 transition-all hover:scale-105">
+        <div className="flex items-center justify-between mb-4">
+          <div className="w-12 h-12 rounded-xl bg-primary-200/20 flex items-center justify-center text-primary-200">
+            <TrendingUp size={24} />
+          </div>
+        </div>
+        <p className="text-3xl font-bold text-primary-200">{averageScore}/100</p>
+        <p className="text-light-100/70 mt-1">Your Average Score</p>
+      </div>
+
+      {/* Peer Comparison */}
+      <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 hover:border-primary-100/30 transition-all hover:scale-105">
+        <div className="flex items-center justify-between mb-4">
+          <div className="w-12 h-12 rounded-xl bg-light-400/20 flex items-center justify-center text-light-400">
+            <Users size={24} />
+          </div>
+        </div>
+        <div className="flex items-baseline gap-2">
+          <p className="text-3xl font-bold text-light-400">{peerAverage}/100</p>
+          {interviewsTaken > 0 && (
+            <span className={`text-sm font-semibold ${isAboveAverage ? 'text-success-100' : 'text-destructive-100'}`}>
+              {isAboveAverage ? '+' : ''}{scoreDiff}
+            </span>
+          )}
+        </div>
+        <p className="text-light-100/70 mt-1">Peer Average</p>
+      </div>
+    </div>
+  );
+}

--- a/components/InterviewTypeDistribution.tsx
+++ b/components/InterviewTypeDistribution.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
+
+interface InterviewTypeDistributionProps {
+  interviews: Array<{
+    id: string;
+    type: string;
+  }>;
+}
+
+const COLORS = {
+  Technical: '#dddfff',
+  Behavioral: '#cac5fe',
+  Mixed: '#6870a6',
+};
+
+export default function InterviewTypeDistribution({ interviews }: InterviewTypeDistributionProps) {
+  // Count interview types
+  const typeCounts = interviews.reduce((acc, interview) => {
+    const type = /technical/i.test(interview.type) ? 'Technical' 
+      : /behavioral/i.test(interview.type) ? 'Behavioral' 
+      : 'Mixed';
+    acc[type] = (acc[type] || 0) + 1;
+    return acc;
+  }, {} as { [key: string]: number });
+
+  const chartData = Object.entries(typeCounts).map(([name, value]) => ({
+    name,
+    value,
+  }));
+
+  const total = chartData.reduce((sum, item) => sum + item.value, 0);
+
+  return (
+    <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 h-full flex flex-col hover:border-primary-100/30 transition-all">
+      <h3 className="text-xl font-semibold text-light-100 mb-6">Interview Types</h3>
+      
+      {chartData.length > 0 ? (
+        <div className="flex-1 flex flex-col justify-between">
+          {/* Pie Chart */}
+          <div className="w-full h-[180px] mb-4">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={40}
+                  outerRadius={70}
+                  fill="#8884d8"
+                  dataKey="value"
+                  paddingAngle={2}
+                >
+                  {chartData.map((entry, index) => (
+                    <Cell 
+                      key={`cell-${index}`} 
+                      fill={COLORS[entry.name as keyof typeof COLORS] || '#6870a6'} 
+                    />
+                  ))}
+                </Pie>
+                <Tooltip 
+                  contentStyle={{ 
+                    backgroundColor: '#27282f', 
+                    border: '1px solid #dddfff',
+                    borderRadius: '8px',
+                    color: '#d6e0ff'
+                  }}
+                  labelStyle={{ color: '#d6e0ff' }}
+                  itemStyle={{ color: '#d6e0ff' }}
+                  cursor={{ fill: 'rgba(221, 223, 255, 0.08)' }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          
+          {/* Legend with counts */}
+          <div className="space-y-3">
+            {chartData.map((item) => {
+              const percentage = ((item.value / total) * 100).toFixed(0);
+              return (
+                <div key={item.name} className="flex items-center justify-between">
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <div 
+                      className="w-3 h-3 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: COLORS[item.name as keyof typeof COLORS] }}
+                    />
+                    <span className="text-light-100 text-sm truncate">{item.name}</span>
+                  </div>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <span className="text-light-100 font-semibold text-sm">{item.value}</span>
+                    <span className="text-light-100/50 text-xs">({percentage}%)</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Total */}
+          <div className="mt-4 pt-4 border-t border-dark-100/20">
+            <div className="flex items-center justify-between">
+              <span className="text-light-100/70 text-sm">Total Interviews</span>
+              <span className="text-primary-100 font-bold text-lg">{total}</span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1 flex flex-col items-center justify-center min-h-[200px]">
+          <p className="text-light-100/70 text-center px-4 mb-2">No interviews created yet.</p>
+          <p className="text-light-100/50 text-xs text-center px-4">Create your first interview to see the distribution</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/PerformanceChart.tsx
+++ b/components/PerformanceChart.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import dayjs from 'dayjs';
+
+interface PerformanceChartProps {
+  data: Array<{
+    id: string;
+    totalScore: number;
+    createdAt: string;
+  }>;
+}
+
+export default function PerformanceChart({ data }: PerformanceChartProps) {
+  const chartData = data.map((item, index) => ({
+    name: dayjs(item.createdAt).format('MMM D'),
+    score: item.totalScore,
+    interview: index + 1,
+  }));
+
+  return (
+    <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 overflow-hidden">
+      <h3 className="text-xl font-semibold text-light-100 mb-6">Performance Over Time</h3>
+      {chartData.length > 0 ? (
+        <div className="w-full" style={{ height: '300px' }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 5, right: 10, left: -20, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#27282f" />
+              <XAxis 
+                dataKey="name" 
+                stroke="#d6e0ff" 
+                style={{ fontSize: '11px' }}
+                tick={{ fill: '#d6e0ff' }}
+              />
+              <YAxis 
+                stroke="#d6e0ff" 
+                style={{ fontSize: '11px' }}
+                domain={[0, 100]}
+                tick={{ fill: '#d6e0ff' }}
+              />
+              <Tooltip 
+                contentStyle={{ 
+                  backgroundColor: '#27282f', 
+                  border: '1px solid #dddfff',
+                  borderRadius: '8px',
+                  color: '#d6e0ff'
+                }}
+              />
+              <Legend 
+                wrapperStyle={{ color: '#d6e0ff' }}
+              />
+              <Line 
+                type="monotone" 
+                dataKey="score" 
+                stroke="#dddfff" 
+                strokeWidth={3}
+                dot={{ fill: '#cac5fe', r: 5 }}
+                activeDot={{ r: 7 }}
+                name="Score"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      ) : (
+        <div className="h-[300px] flex items-center justify-center px-4">
+          <p className="text-light-100/70 text-center">No performance data available yet. Take some interviews to see your progress!</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/RecentInterviews.tsx
+++ b/components/RecentInterviews.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import dayjs from "dayjs";
+import { ArrowRight, Calendar, Star } from "lucide-react";
+import { Button } from "./ui/button";
+
+interface RecentInterviewsProps {
+  interviews: Array<{
+    id: string;
+    interviewId: string;
+    totalScore: number;
+    createdAt: string;
+  }>;
+  title: string;
+}
+
+export default function RecentInterviews({ interviews, title }: RecentInterviewsProps) {
+  return (
+    <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 h-full flex flex-col">
+      <h3 className="text-xl font-semibold text-light-100 mb-6">{title}</h3>
+      
+      {interviews.length > 0 ? (
+        <div className="space-y-4 flex-1 overflow-y-auto max-h-[400px]">
+          {interviews.slice(0, 5).map((interview) => (
+            <Link
+              key={interview.id}
+              href={`/interview/${interview.interviewId}/feedback`}
+              className="block"
+            >
+              <div className="bg-dark-300/50 rounded-lg p-4 border border-dark-100/10 hover:border-primary-100/30 transition-all hover:bg-dark-300">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex flex-wrap items-center gap-3 text-sm text-light-100/70">
+                      <div className="flex items-center gap-2">
+                        <Calendar size={14} className="flex-shrink-0" />
+                        <span className="whitespace-nowrap">{dayjs(interview.createdAt).format('MMM D, YYYY')}</span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Star size={14} className="text-primary-100 flex-shrink-0" />
+                        <span className="text-primary-100 font-semibold whitespace-nowrap">
+                          {interview.totalScore}/100
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <ArrowRight size={18} className="text-light-100/50 flex-shrink-0" />
+                </div>
+              </div>
+            </Link>
+          ))}
+          
+          {interviews.length > 5 && (
+            <Button className="btn-secondary w-full mt-4">
+              View All Interviews
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="text-center py-8 flex-1 flex flex-col items-center justify-center">
+          <p className="text-light-100/70 mb-4">No interviews taken yet.</p>
+          <Button asChild className="btn-primary">
+            <Link href="/">Take Your First Interview</Link>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/UserProfileCard.tsx
+++ b/components/UserProfileCard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Edit2, Save, X } from "lucide-react";
+import { Button } from "./ui/button";
+import { updateUserProfile } from "@/lib/actions/general.action";
+import { toast } from "sonner";
+
+interface UserProfileCardProps {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+  };
+}
+
+export default function UserProfileCard({ user }: UserProfileCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState(user.name);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast.error("Name cannot be empty");
+      return;
+    }
+
+    setIsLoading(true);
+    const result = await updateUserProfile(user.id, { name: name.trim() });
+    setIsLoading(false);
+
+    if (result.success) {
+      toast.success("Profile updated successfully!");
+      setIsEditing(false);
+    } else {
+      toast.error("Failed to update profile. Please try again.");
+    }
+  };
+
+  const handleCancel = () => {
+    setName(user.name);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="bg-dark-200/80 backdrop-blur-sm rounded-2xl p-6 border border-dark-100/20 h-full min-h-[360px] flex flex-col hover:border-primary-100/30 transition-all">
+      <div className="flex items-center justify-between mb-6">
+        <h3 className="text-xl font-semibold text-light-100">Profile Information</h3>
+        {!isEditing && (
+          <Button
+            onClick={() => setIsEditing(true)}
+            className="btn-secondary !min-h-8 !px-3 flex-shrink-0"
+          >
+            <Edit2 size={16} />
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-col items-center text-center mb-6">
+        <div className="w-24 h-24 rounded-full bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center text-dark-100 text-4xl font-bold flex-shrink-0 mb-4 shadow-lg">
+          {name.charAt(0).toUpperCase()}
+        </div>
+
+        {/* Always show summary to keep header height consistent */}
+        <h4 className="text-light-100 text-xl font-semibold break-words mb-1">
+          {name}
+        </h4>
+        <p className="text-light-100/70 text-sm break-all">{user.email}</p>
+      </div>
+
+      {isEditing && (
+        <div className="flex-1 space-y-4 overflow-y-auto">
+          <div>
+            <label className="text-light-100/70 text-sm mb-2 block font-medium">
+              Display Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full bg-dark-300 text-light-100 rounded-lg px-4 py-2.5 border border-dark-100/20 focus:border-primary-100/50 focus:outline-none transition-colors"
+              disabled={isLoading}
+              placeholder="Enter your name"
+            />
+          </div>
+
+          <div>
+            <label className="text-light-100/70 text-sm mb-2 block font-medium">
+              Email Address
+            </label>
+            <div className="w-full bg-dark-300/50 text-light-100/50 rounded-lg px-4 py-2.5 border border-dark-100/10">
+              {user.email}
+            </div>
+            <p className="text-light-100/50 text-xs mt-1">Email cannot be changed</p>
+          </div>
+
+          <div className="flex flex-wrap gap-3 pt-2">
+            <Button
+              onClick={handleSave}
+              disabled={isLoading}
+              className="btn-primary !min-h-10 flex-1 sm:flex-initial"
+            >
+              <Save size={16} className="mr-2" />
+              {isLoading ? "Saving..." : "Save Changes"}
+            </Button>
+            <Button
+              onClick={handleCancel}
+              disabled={isLoading}
+              className="btn-secondary !min-h-10 flex-1 sm:flex-initial"
+            >
+              <X size={16} className="mr-2" />
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/actions/general.action.ts
+++ b/lib/actions/general.action.ts
@@ -139,3 +139,135 @@ export async function getInterviewsByUserId(
     ...doc.data(),
   })) as Interview[];
 }
+
+export async function getUserDashboardStats(userId: string) {
+  try {
+    // Get all user's interviews
+    const userInterviews = await db
+      .collection("interviews")
+      .where("userId", "==", userId)
+      .get();
+
+    // Get all user's feedback
+    const userFeedback = await db
+      .collection("feedback")
+      .where("userId", "==", userId)
+      .get();
+
+    const interviews = userInterviews.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    })) as Interview[];
+
+    const feedbacks = userFeedback.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    })) as Feedback[];
+
+    // Calculate statistics
+    const interviewsCreated = interviews.length;
+    const interviewsTaken = feedbacks.length;
+    
+    const totalScore = feedbacks.reduce((sum, f) => sum + (f.totalScore || 0), 0);
+    const averageScore = feedbacks.length > 0 ? Math.round(totalScore / feedbacks.length) : 0;
+
+    // Get category averages
+    const categoryAverages: { [key: string]: number } = {};
+    if (feedbacks.length > 0) {
+      feedbacks.forEach((feedback) => {
+        feedback.categoryScores?.forEach((cat) => {
+          if (!categoryAverages[cat.name]) {
+            categoryAverages[cat.name] = 0;
+          }
+          categoryAverages[cat.name] += cat.score;
+        });
+      });
+      
+      Object.keys(categoryAverages).forEach((key) => {
+        categoryAverages[key] = Math.round(categoryAverages[key] / feedbacks.length);
+      });
+    }
+
+    // Performance over time (last 10 interviews)
+    const recentFeedbacks = feedbacks
+      .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+      .slice(-10);
+
+    return {
+      interviewsCreated,
+      interviewsTaken,
+      averageScore,
+      categoryAverages,
+      recentFeedbacks,
+      allFeedbacks: feedbacks,
+    };
+  } catch (error) {
+    console.error("Error getting user dashboard stats:", error);
+    return null;
+  }
+}
+
+export async function getPeerAverages() {
+  try {
+    // Get all feedback from all users
+    const allFeedback = await db.collection("feedback").get();
+
+    const feedbacks = allFeedback.docs.map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    })) as Feedback[];
+
+    if (feedbacks.length === 0) {
+      return {
+        averageScore: 0,
+        categoryAverages: {},
+        totalUsers: 0,
+      };
+    }
+
+    // Calculate peer averages
+    const totalScore = feedbacks.reduce((sum, f) => sum + (f.totalScore || 0), 0);
+    const averageScore = Math.round(totalScore / feedbacks.length);
+
+    // Get category averages
+    const categoryAverages: { [key: string]: number } = {};
+    feedbacks.forEach((feedback) => {
+      feedback.categoryScores?.forEach((cat) => {
+        if (!categoryAverages[cat.name]) {
+          categoryAverages[cat.name] = 0;
+        }
+        categoryAverages[cat.name] += cat.score;
+      });
+    });
+
+    Object.keys(categoryAverages).forEach((key) => {
+      categoryAverages[key] = Math.round(categoryAverages[key] / feedbacks.length);
+    });
+
+    // Get unique users count
+    const uniqueUsers = new Set(feedbacks.map((f) => f.userId));
+
+    return {
+      averageScore,
+      categoryAverages,
+      totalUsers: uniqueUsers.size,
+    };
+  } catch (error) {
+    console.error("Error getting peer averages:", error);
+    return {
+      averageScore: 0,
+      categoryAverages: {},
+      totalUsers: 0,
+    };
+  }
+}
+
+export async function updateUserProfile(userId: string, data: { name?: string }) {
+  try {
+    await db.collection("users").doc(userId).update(data);
+    return { success: true };
+  } catch (error) {
+    console.error("Error updating user profile:", error);
+    return { success: false };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
+        "recharts": "^3.4.1",
         "sonner": "^2.0.1",
         "sweetalert2": "^11.6.13",
         "tailwind-merge": "^3.0.2",
@@ -1960,6 +1961,32 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.10.1.tgz",
+      "integrity": "sha512-/U17EXQ9Do9Yx4DlNGU6eVNfZvFJfYpUtRRdLf19PbPjdWBxNlxGZXywQZ1p1Nz8nMkWplTI7iD/23m07nolDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.2.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2048,6 +2075,12 @@
       "engines": {
         "node": ">=14.18"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -2364,6 +2397,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/diff-match-patch": {
       "version": "1.0.36",
       "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
@@ -2589,6 +2685,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.26.1",
@@ -3858,6 +3960,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3950,6 +4173,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4323,6 +4552,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.42.0.tgz",
+      "integrity": "sha512-SLHIyY7VfDJBM8clz4+T2oquwTQxEzu263AyhVK4jREOAwJ+8eebaa4wM3nlvnAqhDrMm2EsA6hWHaQsMPQ1nA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4796,6 +5035,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -5818,6 +6063,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5864,6 +6119,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -7825,8 +8089,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -7841,6 +8127,51 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.4.1.tgz",
+      "integrity": "sha512-35kYg6JoOgwq8sE4rhYkVWwa6aAIgOtT+Ob0gitnShjwUwZmhrmy7Jco/5kJNF4PnLXgt9Hwq+geEMS+WrjU1g==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7901,6 +8232,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -8866,6 +9203,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
@@ -9172,6 +9515,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "recharts": "^3.4.1",
     "sonner": "^2.0.1",
     "sweetalert2": "^11.6.13",
     "tailwind-merge": "^3.0.2",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 interface Feedback {
   id: string;
   interviewId: string;
+  userId: string;
   totalScore: number;
   categoryScores: Array<{
     name: string;


### PR DESCRIPTION
**Summary**

Adds a full user dashboard at /dashboard with analytics, charts, profile editing, and multiple UI fixes. Secures the route behind authentication and improves layout, chart styling, and component stability across the page.

**Key Changes**

- New dashboard page with stats, performance chart, radar chart, type distribution, category breakdown, and recent interviews.

- New profile card with name editing and stable layout.

- Server actions for dashboard stats, peer averages, and profile updates.

- Donut chart redesign, dark-mode tooltip fixes, improved chart containers.

- Fixed “Back to Dashboard” navigation, added Dashboard button in header.

- Removed nested layout; dashboard now uses full width.

**Notes**

- Added userId to Feedback type for aggregation.

- Added recharts dependency.
 
- Legacy feedback without userId may affect peer stats.
 

**Testing**

- Auth redirect works.

- Editing profile persists successfully.

- All charts render correctly in dark mode.
 
- No overflow or layout issues.